### PR TITLE
Preserve URL query params and hash in post-auth redirect

### DIFF
--- a/src/performAuth.ts
+++ b/src/performAuth.ts
@@ -28,7 +28,7 @@ export const createAuthURL = async (
     localStorage.setItem(PKCE_LS_STATE, state);
     localStorage.setItem(PKCE_LS_VERIFIER, verifier);
 
-    localStorage.setItem(LS_BENTO_POST_AUTH_REDIRECT, window.location.pathname);
+    localStorage.setItem(LS_BENTO_POST_AUTH_REDIRECT, `${window.location.pathname}${window.location.search}`);
 
     return (
         `${authorizationEndpoint}?` +

--- a/src/performAuth.ts
+++ b/src/performAuth.ts
@@ -28,7 +28,8 @@ export const createAuthURL = async (
     localStorage.setItem(PKCE_LS_STATE, state);
     localStorage.setItem(PKCE_LS_VERIFIER, verifier);
 
-    localStorage.setItem(LS_BENTO_POST_AUTH_REDIRECT, `${window.location.pathname}${window.location.search}`);
+    const { pathname, search, hash } = window.location;
+    localStorage.setItem(LS_BENTO_POST_AUTH_REDIRECT, `${pathname}${search}${hash}`);
 
     return (
         `${authorizationEndpoint}?` +


### PR DESCRIPTION
This will support Bento Public authorized searches better, since right now refreshing the page while authorized clears the current search.