### PR TITLE
ci: add npm provenance for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
 jobs:
   release:
     name: Release
@@ -23,4 +28,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: npx semantic-release


### PR DESCRIPTION
Adds `id-token: write` permission and `NPM_CONFIG_PROVENANCE=true` to the release workflow so published packages include a signed attestation linking them to this workflow run.