### PR TITLE
fix: persist tokens, silent refresh before redirect on reload

### DIFF
--- a/src/autoAuthenticate.ts
+++ b/src/autoAuthenticate.ts
@@ -1,7 +1,8 @@
 import { useEffect } from "react";
-import { useIsAuthenticated, useIsAutoAuthenticating, useOpenIdConfig } from "./hooks";
+import { useAuthState, useIsAuthenticated, useIsAutoAuthenticating, useOpenIdConfig } from "./hooks";
 import { LS_BENTO_WAS_SIGNED_IN, setLSNotSignedIn, usePerformAuth } from "./performAuth";
-import { setIsAutoAuthenticating } from "./redux/authSlice";
+import { useBentoAuthContext } from "./contexts";
+import { refreshTokens, setIsAutoAuthenticating } from "./redux/authSlice";
 import { useAppDispatch } from "./redux/store";
 
 export interface AutoAuthenticateState {
@@ -17,6 +18,9 @@ export const useAutoAuthenticate = (): AutoAuthenticateState => {
     const { data: openIdConfig } = useOpenIdConfig();
     const performAuth = usePerformAuth();
 
+    const { refreshToken } = useAuthState();
+    const { clientId } = useBentoAuthContext();
+
     const authzEndpoint = openIdConfig?.["authorization_endpoint"];
 
     useEffect(() => {
@@ -29,6 +33,26 @@ export const useAutoAuthenticate = (): AutoAuthenticateState => {
             console.debug("auto-authenticating");
             setLSNotSignedIn();
             dispatch(setIsAutoAuthenticating(true));
+
+            if (refreshToken && clientId) {
+                // We already have a refresh token, so try a silent refresh first - no redirect, no /callback hop.
+                dispatch(refreshTokens(clientId))
+                    .unwrap()
+                    .then(() => {
+                        dispatch(setIsAutoAuthenticating(false));
+                    })
+                    .catch((err) => {
+                        console.error(err);
+                        // Refresh token is dead - fall back to the full redirect flow.
+                        performAuth().catch((err2) => {
+                            console.error(err2);
+                            localStorage.removeItem(LS_BENTO_WAS_SIGNED_IN);
+                            dispatch(setIsAutoAuthenticating(false));
+                        });
+                    });
+                return;
+            }
+
             // If performAuth() is successful, there will be a redirect. Otherwise, an error will be thrown and
             // isAutoAuthenticating will be reset to `false`.
             performAuth().catch((err) => {
@@ -39,7 +63,7 @@ export const useAutoAuthenticate = (): AutoAuthenticateState => {
                 dispatch(setIsAutoAuthenticating(false));
             });
         }
-    }, [dispatch, authzEndpoint, isAuthenticated, isAutoAuthenticating, performAuth]);
+    }, [dispatch, authzEndpoint, isAuthenticated, isAutoAuthenticating, performAuth, refreshToken, clientId]);
 
     return { isAutoAuthenticating };
 };

--- a/src/redux/authSlice.ts
+++ b/src/redux/authSlice.ts
@@ -166,6 +166,47 @@ const nullSession = {
     refreshToken: undefined,
 };
 
+export const LS_BENTO_AUTH_TOKENS = "BENTO_AUTH_TOKENS";
+
+type PersistedTokens = {
+    accessToken?: string;
+    idToken?: string;
+    refreshToken?: string;
+    sessionExpiry?: number;
+};
+
+const persistTokens = (state: AuthSliceState) => {
+    const { accessToken, idToken, refreshToken, sessionExpiry } = state;
+    localStorage.setItem(LS_BENTO_AUTH_TOKENS, JSON.stringify({ accessToken, idToken, refreshToken, sessionExpiry }));
+};
+
+const clearPersistedTokens = () => {
+    localStorage.removeItem(LS_BENTO_AUTH_TOKENS);
+};
+
+const loadPersistedTokens = (): Pick<
+    AuthSliceState,
+    "accessToken" | "idToken" | "idTokenContents" | "refreshToken" | "sessionExpiry"
+> | null => {
+    const raw = localStorage.getItem(LS_BENTO_AUTH_TOKENS);
+    if (!raw) return null;
+
+    try {
+        const parsed = JSON.parse(raw) as PersistedTokens;
+        if (!parsed.refreshToken || !parsed.idToken) return null;
+
+        return {
+            accessToken: parsed.accessToken,
+            idToken: parsed.idToken,
+            idTokenContents: decodeJwt(parsed.idToken),
+            refreshToken: parsed.refreshToken,
+            sessionExpiry: parsed.sessionExpiry,
+        };
+    } catch {
+        return null;
+    }
+};
+
 export type AuthSliceState = {
     loading: boolean;
     hasAttempted: boolean;
@@ -207,6 +248,8 @@ const initialState: AuthSliceState = {
     isAutoAuthenticating: false,
 
     resourcePermissions: {},
+
+    ...loadPersistedTokens(),
 };
 
 const setTokenStateFromPayload = (state: AuthSliceState, payload: TokenHandoffPayload | RefreshTokenPayload) => {
@@ -217,6 +260,8 @@ const setTokenStateFromPayload = (state: AuthSliceState, payload: TokenHandoffPa
     state.idTokenContents = decodeJwt(idToken);
     state.accessToken = accessToken;
     state.refreshToken = refreshToken ?? state.refreshToken;
+
+    persistTokens(state);
 };
 
 export const authSlice = createSlice({
@@ -225,6 +270,7 @@ export const authSlice = createSlice({
     reducers: {
         signOut: (state) => {
             setLSNotSignedIn();
+            clearPersistedTokens();
 
             Object.assign(state, {
                 ...state,
@@ -259,6 +305,7 @@ export const authSlice = createSlice({
                     resourcePermissions: {},
                 });
                 setLSNotSignedIn();
+                clearPersistedTokens();
             })
             .addCase(refreshTokens.pending, (state) => {
                 state.isRefreshingTokens = true;
@@ -283,6 +330,7 @@ export const authSlice = createSlice({
                 });
 
                 setLSNotSignedIn();
+                clearPersistedTokens();
             })
             .addCase(setIsAutoAuthenticating, (state, { payload }) => {
                 state.isAutoAuthenticating = payload;


### PR DESCRIPTION
Summary
- Persist accessToken/idToken/refreshToken/sessionExpiry to a new LS_BENTO_AUTH_TOKENS localStorage key on every successful token handoff/refresh, and rehydrate it into initialState on load - fixes instant-reload case (authenticated immediately, no network call, if idToken not yet expired).
- Auto-authenticate now tries a silent refreshTokens(clientId) grant first when a refresh token is present, only falling back to the full performAuth() redirect if that fails or no refresh token exists.
- Clear persisted tokens on signOut, tokenHandoff.rejected, and refreshTokens.rejected.