### PR TITLE
fix: log missing local state as debug, not error

### DIFF
--- a/src/performAuth.ts
+++ b/src/performAuth.ts
@@ -154,7 +154,7 @@ export const useHandleCallback = (
 
         const localState = popLocalStorageItem(PKCE_LS_STATE);
         if (!localState) {
-            console.error("no local state");
+            console.debug("no local state");
             setLSNotSignedIn();
             return;
         }


### PR DESCRIPTION
## Summary
- Missing local state during OIDC callback handling is expected on normal navigation (reload/back) without a pending auth flow, so it's logged as `console.debug` instead of `console.error`.